### PR TITLE
fixes 0x01 and 0x02 delimiter bugs in #1 for both encoding and decoding

### DIFF
--- a/src/RFC8188.php
+++ b/src/RFC8188.php
@@ -35,58 +35,60 @@ class RFC8188
         $idlen = hexdec(substr($payload_hex, 40, 1*2));
         $header_boundary = 42 + $idlen*2;
         $keyid = hex2bin(substr($payload_hex, 42, $idlen*2));
-    
+        
         if ($keyid) {
             $key = $keys[$keyid];
         } else {
             // If the key ID is not provided, then attempt using the first and likely only key.
-            $key = $keys[0];
+            $key = array_pop($keys);
         }
         
         $encoded_body = substr($payload_hex, $header_boundary);
     
         $records = str_split($encoded_body, ($rs*2));
-    
+
         $return = "";
+        
         // decrypt each record
         for ($s=0; $s<count($records); $s++) {
             $r = hex2bin($records[$s]);
-            
-            // // check and fail for no non-zero octet
-            // for($i=0; $i<strlen($r)/2; $i++){
-            //     $octet = substr($r, $i, $i+1);
-            //     if(hexdec($octet) != 0x00) {
-            //         break; // non-zero octet, no failure, break check and continue
-            //     }
-            // }
-    
-            // // check and fail if the last record contains padding other than 0x02
-            // if (count($records)-1 == $s) {
-            //     // This is the last record
-            //     $padding_delim = substr($r, -34, 2);
-            //     if(hexdec($padding_delim) != 0x2) {
-            //         echo "EXPECTED 0x02 AS PADDING DELIM";
-            //     }
-            // }
-    
-            $block = substr($r, 0, strlen($r)-16);
+            $ciphertext = substr($r, 0, strlen($r)-16);
             $tag = substr($r, strlen($r)-16);
     
             $hkdf = self::hkdf($salt, $key, $s);
 
             // decrypt
-            $decrypted_record = openssl_decrypt($block, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
+            $decrypted_record = openssl_decrypt($ciphertext, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
             if (false === $decrypted_record) {
-                throw new Exception(sprintf(
-                    "OpenSSL error: %s", openssl_error_string()
+                throw new \Exception(sprintf(
+                    "OpenSSL error: %s",
+                    openssl_error_string()
                 ));
             }
-            $return .= $decrypted_record;
-            
-            // todo check and fail if the record isn't last and isn't padded with 0x1
-        }
 
-        return $decrypted_record;
+            // Check for the padding delim and remove it.
+            for ($i=strlen($decrypted_record); $i>0; $i--) {
+                $byte = bin2hex(substr($decrypted_record, $i-1, 1));
+                
+                if ($byte === 0x00) {
+                    continue;
+                } elseif ($byte == 0x02) {
+                    // 0x02 is only used for the last record
+                    if ($s !== count($records)-1) {
+                        throw new \Exception("Invalid encoding. 0x02");
+                    }
+                    // Slice off the padding.
+                    $unpadded_record = substr($decrypted_record, 0, strlen($decrypted_record)-$i-1);
+                    $return .= $unpadded_record;
+                } elseif ($byte == 0x01) {
+                    // Found a 0x01 delimiter. Slice off the padding.
+                    $unpadded_record = substr($decrypted_record, 0, strlen($decrypted_record)-$i-1);
+                    $return .= $unpadded_record;
+                }
+            }
+        }
+        
+        return $return;
     }
 
     public static function rfc8188_encode($payload, $key, $keyid=null, $rs=25)
@@ -101,29 +103,31 @@ class RFC8188
 
         $return = $header; // $header is the first chunk of the return body
 
+        $plaintext_records = str_split($payload, $rs-16);
         // Process records
-        $pages = ceil(strlen($payload) / ($rs-17));
-
-        for ($p=0; $p<$pages; $p++) {
+        $number_of_records = count($plaintext_records);
+        for ($p=0; $p<count($plaintext_records); $p++) {
             // For each 'page' in the payload, create and encrypt a record.
-            if ($p == $pages - 1) {
-                // last page, take the remaining plaintext
-                $record_plaintext = substr($payload, $p*$rs)."\x02";
+            if ($p == $number_of_records - 1) {
+                // last page, take the remaining plaintext with 0x02
+                $record_plaintext = substr($payload, $p*($rs-16))."\x02";    
             } else {
-                $record_plaintext = substr($payload, $p*$rs, $rs)."\0x01";
+                // 0x01 delimits padding in each record
+                $record_plaintext = substr($payload, $p*($rs-16), $rs)."\0x01";
                 $record_plaintext = str_pad($record_plaintext, $rs, "\x00", STR_PAD_RIGHT);
             }
 
             $hkdf = self::hkdf($salt, $key, $p);
 
-            $encrypted = openssl_encrypt($payload, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
+            $encrypted = openssl_encrypt($record_plaintext, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
         
             if (false === $encrypted) {
                 throw new Exception(sprintf(
                     "OpenSSL error: %s", openssl_error_string()
                 ));
             }
-            $return .= $encrypted.$tag;
+            $block = $encrypted.$tag;
+            $return .= $block;
         }
         return $return;
     }

--- a/test/RFC8188Test.php
+++ b/test/RFC8188Test.php
@@ -22,6 +22,18 @@ final class RFC8188Test extends TestCase
         $this->assertEquals("I am the walrus", $decoded);
     }
 
+    public function testDecryptRFC8188Example32(): void 
+    {
+        $encoded = b64::decode("uNCkWiNYzKTnBN9ji3-qWAAAABkCYTHOG8chz_gnvgOqdGYovxyjuqRyJFjEDyoF1Fvkj6hQPdPHI51OEUKEpgz3SsLWIqS_uA");
+        
+        $decoded = RFC8188::rfc8188_decode(
+            $encoded, // data to decode 
+            ['a1' => b64::decode("BO3ZVPxUlnLORbVGMpbT1Q")] // Keys
+        );
+
+        $this->assertEquals("I am the walrus", $decoded);
+    }
+
     public function testIAmTheWalrus(): void
     {
         $keys = [

--- a/test/RFC8188Test.php
+++ b/test/RFC8188Test.php
@@ -9,18 +9,31 @@ use Base64Url\Base64Url as b64;
 
 final class RFC8188Test extends TestCase
 {
+
+    public function testDecryptRFC8188Example31(): void
+    {
+        $encoded = b64::decode("I1BsxtFttlv3u_Oo94xnmwAAEAAA-NAVub2qFgBEuQKRapoZu-IxkIva3MEB1PD-ly8Thjg");
+        
+        $decoded = RFC8188::rfc8188_decode(
+            $encoded, // data to decode 
+            [b64::decode("yqdlZ-tYemfogSmv7Ws5PQ")] // Keys
+        );
+
+        $this->assertEquals("I am the walrus", $decoded);
+    }
+
     public function testIAmTheWalrus(): void
     {
         $keys = [
             b64::decode('yqdlZ-tYemfogSmv7Ws5PQ'),
         ];
-        $message = "I Am the walrus";
+        $message = "I am the walrus";
 
         $encoded = RFC8188::rfc8188_encode(
             $message, // plaintext
             b64::decode("yqdlZ-tYemfogSmv7Ws5PQ"), // encryption key
             null,   // key ID
-            4096    // record size.
+            132    // record size.
         );
         $decoded = RFC8188::rfc8188_decode(
             $encoded, // data to decode 

--- a/test/RFC8188Test.php
+++ b/test/RFC8188Test.php
@@ -54,4 +54,29 @@ final class RFC8188Test extends TestCase
 
         $this->assertEquals($message, $decoded);
     }
+
+
+    public function testMultiRecordParagraphs(): void
+    {
+        $key = \random_bytes(16);
+    
+        $message = "I am the egg man
+        They are the egg men
+        I am the walrus
+        Goo goo g'joob, goo goo goo g'joob
+        Goo goo g'joob, goo goo goo g'joob, goo goo";
+
+        $encoded = RFC8188::rfc8188_encode(
+            $message, // plaintext
+            $key, // encryption key
+            '',   // key ID
+            30    // record size.
+        );
+        $decoded = RFC8188::rfc8188_decode(
+            $encoded, // data to decode 
+            [$key] // Keys
+        );
+
+        $this->assertEquals($message, $decoded);
+    }
 }


### PR DESCRIPTION
Correctly pads (and un-pads) records as specified in RFC8188.
Adds tests based on examples in RFC8188 Section 3.1
