### PR TITLE
Feature/php 56 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 before_script: composer install
 script: ./vendor/bin/phpunit --bootstrap vendor/autoload.php test
 php:
+  - '5.6'
   - '7.1'
   - '7.2'
   - nightly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:5.6-cli
+
+MAINTAINER Jack Skinner
+
+RUN apt-get update
+RUN apt-get install -y python-pip
+RUN pip install -U pip
+RUN pip install pywatch
+RUN curl -sS https://getcomposer.org/installer | php \
+  && chmod +x composer.phar && mv composer.phar /usr/local/bin/composer
+RUN apt-get install -y git unzip
+
+WORKDIR /opt
+
+# ENTRYPOINT ["sh"]
+
+

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "ext-openssl": "*",
-        "spomky-labs/base64url": "^2.0"
+        "spomky-labs/base64url": "^1.0",
+        "paragonie/random_compat": "<9.99"
     },
     "autoload": {
         "psr-4": {
@@ -30,6 +31,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "docs": "https://github.com/devjack/encrypted-content-encoding"
     },
     "require": {
+        "php": "~5.6 || >=7.1",
         "ext-openssl": "*",
         "spomky-labs/base64url": "^1.0",
         "paragonie/random_compat": "<9.99",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "ext-openssl": "*",
         "spomky-labs/base64url": "^1.0",
-        "paragonie/random_compat": "<9.99"
+        "paragonie/random_compat": "<9.99",
+        "spomky-labs/php-aes-gcm": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/RFC8188.php
+++ b/src/RFC8188.php
@@ -2,6 +2,7 @@
 namespace DevJack\EncryptedContentEncoding;
 
 use Base64Url\Base64Url as b64;
+use AESGCM\AESGCM;
 
 class RFC8188
 {
@@ -59,7 +60,13 @@ class RFC8188
             $hkdf = self::hkdf($salt, $key, $s);
 
             // decrypt
-            $decrypted_record = openssl_decrypt($ciphertext, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
+            if (version_compare(phpversion(), '7.0.0', '>')) {
+                $decrypted_record = openssl_decrypt($ciphertext, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
+            } else {
+                // Attempt PHP 5.6 compat
+                $decrypted_record = AESGCM::decryptWithAppendedTag($hkdf['cek'], $hkdf['nonce'], $ciphertext.$tag, null, 128);
+            }
+
             if (false === $decrypted_record) {
                 throw new \Exception(sprintf(
                     "OpenSSL error: %s",
@@ -113,15 +120,18 @@ class RFC8188
             }
 
             $hkdf = self::hkdf($salt, $key, $p);
-
-            $encrypted = openssl_encrypt($plaintext_record, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
-        
-            if (false === $encrypted) {
-                throw new Exception(sprintf(
-                    "OpenSSL error: %s", openssl_error_string()
-                ));
+            if (version_compare(phpversion(), '7.0.0', '>')) {
+                $encrypted = openssl_encrypt($plaintext_record, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
+                $block = $encrypted.$tag;
+                if (false === $encrypted) {
+                    throw new Exception(sprintf(
+                        "OpenSSL error: %s", openssl_error_string()
+                    ));
+                }
+            } else {
+                // Attempt PHP 5.6 compat
+                $block = AESGCM::encryptAndAppendTag($hkdf['cek'],$hkdf['nonce'], $plaintext_record, null);
             }
-            $block = $encrypted.$tag;
             $return .= $block;
         }
         return $return;

--- a/src/RFC8188.php
+++ b/src/RFC8188.php
@@ -88,7 +88,7 @@ class RFC8188
     public static function rfc8188_encode($payload, $key, $keyid=null, $rs=25)
     {
         // Calculate header:
-        $salt = random_bytes(16);
+        $salt = \random_bytes(16);
         $header = bin2hex($salt)
             .(sprintf('%08X', $rs))
             .bin2hex(pack("C", strlen($keyid)))

--- a/test/RFC8188Test.php
+++ b/test/RFC8188Test.php
@@ -75,4 +75,32 @@ final class RFC8188Test extends TestCase
 
         $this->assertEquals($message, $decoded);
     }
+
+    /**
+     * @requires PHP 5.6
+     */
+    public function testCanPHP56DecodePHP71EncodedContent() {
+
+        // Encoded using PHP 7.2.9
+        $encoded = b64::decode("Nviu8NbdiSGm-tFxx1-2-gAAAIQAWoS9c1AaFoN_B_EXtQnnpaNWsADFk_inb1ijxvNouLM");
+        $decoded = RFC8188::rfc8188_decode(
+            $encoded, // data to decode 
+            function($keyid ) { return b64::decode("yqdlZ-tYemfogSmv7Ws5PQ"); }
+        );
+        $this->assertEquals("I am the walrus", $decoded);
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testCanPHP7xDecodePHP56EncodedContent() {
+
+        // Encoded using PHP 7.2.9
+        $encoded = b64::decode("SCzPAGhMcr2rHMPIS5iszgAAAIQA-FA0NUiBf4x6opiYp6x8QjJSuRF6l71uqaT_CbSkXiY");
+        $decoded = RFC8188::rfc8188_decode(
+            $encoded, // data to decode 
+            function($keyid ) { return b64::decode("yqdlZ-tYemfogSmv7Ws5PQ"); }
+        );
+        $this->assertEquals("I am the walrus", $decoded);
+    }
 }

--- a/test/RFC8188Test.php
+++ b/test/RFC8188Test.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 namespace DevJack\EncryptedContentEncoding\Test;
 
 use PHPUnit\Framework\TestCase;
@@ -10,7 +9,7 @@ use Base64Url\Base64Url as b64;
 final class RFC8188Test extends TestCase
 {
 
-    public function testDecryptRFC8188Example31(): void
+    public function testDecryptRFC8188Example31()
     {
         $encoded = b64::decode("I1BsxtFttlv3u_Oo94xnmwAAEAAA-NAVub2qFgBEuQKRapoZu-IxkIva3MEB1PD-ly8Thjg");
         
@@ -22,7 +21,7 @@ final class RFC8188Test extends TestCase
         $this->assertEquals("I am the walrus", $decoded);
     }
 
-    public function testDecryptRFC8188Example32(): void 
+    public function testDecryptRFC8188Example32()
     {
         $encoded = b64::decode("uNCkWiNYzKTnBN9ji3-qWAAAABkCYTHOG8chz_gnvgOqdGYovxyjuqRyJFjEDyoF1Fvkj6hQPdPHI51OEUKEpgz3SsLWIqS_uA");
         
@@ -34,7 +33,7 @@ final class RFC8188Test extends TestCase
         $this->assertEquals("I am the walrus", $decoded);
     }
 
-    public function testIAmTheWalrus(): void
+    public function testIAmTheWalrus()
     {
         $message = "I am the walrus";
 
@@ -53,7 +52,7 @@ final class RFC8188Test extends TestCase
     }
 
 
-    public function testMultiRecordParagraphs(): void
+    public function testMultiRecordParagraphs()
     {
         $key = \random_bytes(16);
 


### PR DESCRIPTION
Adds PHP 5.6 compatibility for hosts still stuck on PHP 5.6
 - falls back to a userspace aes-128-gcm implementation
 - Removes PHP 7 specific syntax
 - Adds tests for decoding between versions.
 - Pins PHP 5.6 || 7.1+ versions in composer.