### PR TITLE
Bugfix/exceptions

### DIFF
--- a/src/Exception/EncryptionKeyNotFound.php
+++ b/src/Exception/EncryptionKeyNotFound.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace DevJack\EncryptedContentEncoding\Exception;
+
+class EncryptionKeyNotFound extends \Exception {
+
+}

--- a/src/RFC8188.php
+++ b/src/RFC8188.php
@@ -25,7 +25,7 @@ class RFC8188
     public static function rfc8188_decode($payload, $key_lookup)
     {       
         if (!is_callable($key_lookup)) {
-            throw new Exception(sprintf(
+            throw new \Exception(sprintf(
                 '$key_lookup must be invocable'
             ));
         }
@@ -124,7 +124,7 @@ class RFC8188
                 $encrypted = openssl_encrypt($plaintext_record, "aes-128-gcm", $hkdf['cek'], OPENSSL_RAW_DATA, $hkdf['nonce'], $tag);
                 $block = $encrypted.$tag;
                 if (false === $encrypted) {
-                    throw new Exception(sprintf(
+                    throw new \Exception(sprintf(
                         "OpenSSL error: %s", openssl_error_string()
                     ));
                 }

--- a/test/Mock/MockKeyLookupProvider.php
+++ b/test/Mock/MockKeyLookupProvider.php
@@ -1,0 +1,19 @@
+<?php
+namespace DevJack\EncryptedContentEncoding\Test\Mock;
+
+use DevJack\EncryptedContentEncoding\Exception\EncryptionKeyNotFound;
+
+class MockKeyLookupProvider {
+
+    protected $keys = [];
+
+    public function addKey($key, $keyid='') {
+        $this->keys[$keyid] = $key;
+    }
+    public function __invoke($keyid) {
+        if (in_array($keyid, array_keys($this->keys))) {
+            return $this->keys[$keyid];
+        }
+        throw new EncryptionKeyNotFound("Encryption key not found.");
+    }
+}


### PR DESCRIPTION
 - Fixes class not found references where a leading `\` was missing.
 - Improves documentation and tests around key lookup usage.