### PR TITLE
Remove random_compat dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-before_script: composer install
+before_script: composer install && composer require paragonie/random_compat
 script: ./vendor/bin/phpunit --bootstrap vendor/autoload.php test
 php:
   - '5.6'

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ $decoded = RFC8188::rfc8188_decode(
 
 ## Installation
 
+Available via composer.
+
 ```
 composer require devjack/encrypted-content-encoding
 ```
+
+### PHP 5.6 compatibility
+Additionally, install a polyfill for random_bytes such as:
+
+```
+composer require paragonie/random_compat
+```
+

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
         "php": "~5.6 || >=7.1",
         "ext-openssl": "*",
         "spomky-labs/base64url": "^1.0",
-        "paragonie/random_compat": "<9.99",
         "spomky-labs/php-aes-gcm": "^1.2"
+    },
+    "suggest": {
+        "paragonie/random_compat": "Pollyfill for \random_bytes(). REQUIRED for PHP 5.x"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
random_compat isn't required for PHP 7.
 - Document the combat dependency
 - Suggest `paragonie/random_compat`
 - Removes the dependency from composer `requires`