### PR TITLE
adds a key provider interface for type hinting.

### DIFF
--- a/src/EncryptionKeyProviderInterface.php
+++ b/src/EncryptionKeyProviderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DevJack\EncryptedContentEncoding;
+
+interface EncryptionKeyProviderInterface {
+    /*
+     * EncryptionKeyProvider's must be invokable.
+     */
+    public function __invoke($keyid);
+}

--- a/test/Mock/MockKeyLookupProvider.php
+++ b/test/Mock/MockKeyLookupProvider.php
@@ -2,8 +2,9 @@
 namespace DevJack\EncryptedContentEncoding\Test\Mock;
 
 use DevJack\EncryptedContentEncoding\Exception\EncryptionKeyNotFound;
+use DevJack\EncryptedContentEncoding\EncryptionKeyProviderInterface;
 
-class MockKeyLookupProvider {
+class MockKeyLookupProvider implements EncryptionKeyProviderInterface {
 
     protected $keys = [];
 


### PR DESCRIPTION
Dependant libraries/middleware/frameworks can use this interface as a typehint for dependency injection purposes.

Mock key lookup provider now uses this interface as part of the tests